### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/paulmuir1981/skittles/security/code-scanning/1](https://github.com/paulmuir1981/skittles/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only performs read operations (e.g., checking out code and restoring dependencies), the `contents: read` permission is sufficient. This block can be added at the root level of the workflow to apply to all jobs, or within the `build` job specifically.

The best approach is to add the `permissions` block at the root level of the workflow, as this ensures consistency and avoids redundancy if additional jobs are added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
